### PR TITLE
Fix up slack Private Messages

### DIFF
--- a/adapter/slack/slack.go
+++ b/adapter/slack/slack.go
@@ -138,6 +138,11 @@ func (a *adapter) Receive(msg *hal.Message) error {
 
 		if a.inChannels(msg.Room) {
 			hal.Logger.Debugf("slack - %s in whitelist", msg.Room)
+			if msg.Room == a.botname {
+				hal.Logger.Debugf("slack - recieved direct message to bot, reply to %v", msg.User)
+				msg.Room = msg.User.Name
+				msg.Text = fmt.Sprintf("%s: %s", a.botname, msg.Text)
+			}
 			hal.Logger.Debug("slack - adapter sent message to robot")
 			return a.Robot.Receive(msg)
 		}


### PR DESCRIPTION
The bot would not respond to private messages. We can get this working
by munging the message on the way in. For direct messages addressed to
a room that matches the bot name, we reply to the a room matching the
source user's name, and we fix up the message to look like it was
directly targeted at us