### PR TITLE
implement chores (sheduled tasks)

### DIFF
--- a/chore.go
+++ b/chore.go
@@ -1,0 +1,104 @@
+package hal
+
+import (
+	"fmt"
+	"time"
+	"github.com/gorhill/cronexpr"
+)
+
+type Chore struct {
+	Name 		string
+	Usage 	string
+	Sched 	string
+	Room		string
+	State 	string
+	Resp 		*Response
+	Run 		func(*Response) error
+	Next 		time.Time
+	Timer 	*time.Timer
+}
+
+func (c *Chore) Trigger(){
+	Logger.Debug("Triggered: ",c.Name)
+	c.State="running"
+	go c.Run(c.Resp)
+	StartChore(c)
+}
+
+// NewResponseFromThinAir returns a new Response object pointing at the general room
+func NewResponseFromThinAir(robot *Robot, room string) *Response {
+   return &Response{
+      Robot: robot,
+      Envelope: &Envelope{
+         Room: room,
+			User: &User{
+				ID: `0`,
+				Name: Config.Name,
+			},
+      },
+      Message: &Message{
+			Room: room,
+			Text: `thin air!`,
+			Type: `chore`,
+   	},
+	}
+}
+
+// initialize and schedule the chores
+func (robot *Robot) Schedule(chores ...*Chore) error{
+	for _, c := range chores {
+		c.Resp = NewResponseFromThinAir(robot, c.Room)
+		StartChore(c)
+		Logger.Debug("appending chore: ",c.Name, " to robot.Chores")
+		robot.Chores = append(robot.Chores, c)
+	}
+	return nil
+}
+
+func KillChore(c *Chore) error{
+	Logger.Debug(`Stopping: `,c.Name)
+	c.State=`Halted by request`
+	c.Timer.Stop()
+	return nil
+}
+
+func StartChore(c *Chore) error{
+	Logger.Debug("Re-Starting: ",c.Name)
+	expr := cronexpr.MustParse(c.Sched)
+	if expr.Next(time.Now()).IsZero(){
+		Logger.Debug("invalid schedule",c.Sched)
+		c.State=fmt.Sprintf("NOT Scheduled (invalid Schedule: %s)",c.Sched)
+	}else{
+		Logger.Debug("valid Schedule: ",c.Sched)
+		c.Next = expr.Next(time.Now())
+		dur := c.Next.Sub(time.Now())
+			if dur>0{
+				Logger.Debug("valid duration: ",dur)
+				Logger.Debug("testing timer.. ")
+				if c.Timer == nil{
+					Logger.Debug("creating new timer ")
+					c.Timer = time.AfterFunc(dur, c.Trigger) // auto go-routine'd
+				}else{
+					Logger.Debug("pre-existing timer found, resetting to: ",dur)
+					c.Timer.Reset(dur) // auto go-routine'd
+				}
+			c.State=fmt.Sprintf("Scheduled: %s",c.Next.String())
+			}else{
+				Logger.Debug("invalid duration",dur)
+				c.State=fmt.Sprintf("Halted. (invalid duration: %s)",dur)
+			}
+		}
+	Logger.Debug("all set! Chore: ",c.Name, "scheduled at: ",c.Next)
+	return nil
+}
+
+func GetChoreByName(name string, robot *Robot) *Chore{
+	for _, c := range robot.Chores {
+		if c.Name == name{
+			return c
+		}else{
+			Logger.Debug("chore not found: ",name)
+		}
+	}
+	return nil
+}

--- a/examples/chores/choreCommands.go
+++ b/examples/chores/choreCommands.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/danryan/hal"
+	"time"
+	"strings"
+)
+
+// Ask your bot for the ID of the current Room
+var ListRooms = &hal.Handler{
+	Method:  hal.RESPOND,
+	Pattern: `(what room)|(list *room)|(room *list)`,
+	Run: func(res *hal.Response) error {
+		room := res.Message.Room
+		reply := fmt.Sprintf("Current room is: %s",room)
+		return res.Send(reply)
+	},
+}
+
+// List all initialized chores (running or not)
+var ListChores = &hal.Handler{
+	Method:  hal.RESPOND,
+	Pattern: `(list chores)|(chore list)`,
+	Run: func(res *hal.Response) error {
+		var reply string
+		if len(res.Robot.Chores) == 0{
+			reply=`No chores have been registered (sorry?)`
+		}else{
+			reply=`Name  :small_blue_diamond:  Schedule  :small_blue_diamond:  Firing in  :small_blue_diamond: Current State`
+			for _,c := range res.Robot.Chores{
+				reply = fmt.Sprintf("%s\n%s:small_blue_diamond:%s:small_blue_diamond:%v:small_blue_diamond:%s",reply,c.Name, c.Sched, c.Next.Sub(time.Now()), c.State)
+			}
+		}
+		return res.Reply(reply)
+	},
+}
+
+// Stop or start individual chores by name
+var ManageChores = &hal.Handler{
+	Method:  hal.RESPOND,
+	Pattern: `(start|stop) chore .*`,
+	Run: func(res *hal.Response) error {
+		var reply string
+		cname:=strings.SplitAfterN(res.Match[0],` `,4)
+		c:=hal.GetChoreByName(cname[3],res.Robot)
+		if c == nil{ 
+			reply = fmt.Sprintf("Chore not found: %s",(cname[3]))
+		}else{
+			if cname[1]==`stop `{
+				hal.KillChore(c)
+			}else{
+				hal.StartChore(c)
+			}
+			reply = fmt.Sprintf("%s\n%s:small_blue_diamond:%s:small_blue_diamond:%v:small_blue_diamond:%s",reply,c.Name, c.Sched, c.Next.Sub(time.Now()), c.State)
+		}
+		return res.Reply(reply)
+	},
+}

--- a/examples/chores/choretest.go
+++ b/examples/chores/choretest.go
@@ -1,0 +1,16 @@
+package bothandlers
+
+import (
+	"github.com/danryan/hal"
+)
+
+// runs once a minute. Prints 'successful test' to the room of your choosing
+var ChoreTest = &hal.Chore{
+	Name:  `test-chore`,
+	Sched: `0 * * * * * *`,
+	Room: `<ENTER YOUR GENERAL ROOM NUMBER`,
+	//you can use the 'listRooms' handler in choreHandlers.go to find your room number
+	Run: func(res *hal.Response) error {
+		return res.Send(`successful test!`)
+	},
+}

--- a/examples/complex/main.go
+++ b/examples/complex/main.go
@@ -61,6 +61,11 @@ func run() int {
 		}),
 	)
 
+	//while we're at it, schedule a chore
+	robot.Schedule(
+		handlers.ChoreTest,
+	)
+
 	if err := robot.Run(); err != nil {
 		hal.Logger.Error(err)
 		return 1

--- a/robot.go
+++ b/robot.go
@@ -15,6 +15,7 @@ type Robot struct {
 	Adapter    Adapter
 	Store      Store
 	handlers   []handler
+	Chores	  []*Chore
 	Users      *UserMap
 	Auth       *Auth
 	signalChan chan os.Signal


### PR DESCRIPTION
Curious what you think about this.. 

There are several things I want my various bots to do on a daily or hourly basis (like check the status of RSS feeds).  It's possible now to create a handler with a pattern of "", and use it to setup and manage timers inside my handler.  I think the attached approach is more elegant.  It gives the user the ability to setup a special kind of handler called a 'chore'.  The user specifies a chore type, which includes a crontab-style schedule, and the bot figures out the duration to the next date/time that meets the schedule, and fires a goroutine to launch the user-specified run() function attached to the chore when the timer expires.  Some simple handlers are included to get the bot to list all registered chores as well as, start, and stop individual chores as needed. 

![screen shot 2014-12-12 at 4 00 35 pm](https://cloud.githubusercontent.com/assets/1113505/5420199/67b54a0e-8218-11e4-83e3-8101e29669cd.png)
